### PR TITLE
Add SMF98.1 record parser and basic plugin

### DIFF
--- a/SMF-Tools/.gitignore
+++ b/SMF-Tools/.gitignore
@@ -2,4 +2,5 @@ target/
 bin/
 .classpath
 .project
+.settings
 dependency-reduced-pom.xml

--- a/SMF-Tools/SMF_CORE/readme.md
+++ b/SMF-Tools/SMF_CORE/readme.md
@@ -2,7 +2,7 @@
 ```
 ** Beginning of Copyright and License **
 
-Copyright 2021 IBM Corp.                                           
+Copyright 2024 IBM Corp.                                           
                                                                     
 Licensed under the Apache License, Version 2.0 (the "License");    
 you may not use this file except in compliance with the License.   
@@ -23,10 +23,9 @@ limitations under the License.
 
 This is a Java program intended to read and process z/OS
 SMF records.  This project forms the core and defines the
-interfaces used.  Support for parsing individual SMF 
-records is provided by other projects.  Other projects 
-also may implement plugins which are called at key points
-in processing to help produce reports, etc.  
+interfaces used as well as some core SMF records and plugins.
+Other projects may implement product-specific records
+and plugins to help produce reports, etc.  
 
 ## Adding Support for SMF Record Types (and subtypes)
 
@@ -52,7 +51,7 @@ up the record type being supported.
 
 Implementers typically also override the `dump( )` method.  It is
 usually only called if no plugin is provided and
-`-DPRINT_DETAILS=YES` is set. The base `SMFRecord` implementation
+`-DPRINT_DETAILS=true` is set. The base `SMFRecord` implementation
 just prints the header, but specific record type implementations
 may choose to print out a long-form formatted version of the record.
 This can be helpful if you are just looking at one single record and
@@ -108,6 +107,12 @@ this method.
 One instance of the plugin is created for the entire run, so you can use
 object attributes to hold summary data etc. along the way.  
 
+## Core plugins
+
+- **Type98CPU** - Create a CSV from type 98.1 records with the timestamp,
+  average percent CP, zAAP, and zIIP used, and largest CPU-consuming address
+  space names for CP, zAAP, and zIIP.
+
 ## Invoking from the shell
 
 Assuming the .jar files for the core SMF processor plus any needed
@@ -121,7 +126,7 @@ SMF data dumped via the IFASMFDP utility.
 
 Without a plugin specified:
 
-* If `-DPRINT_DETAILS=YES` is not set (the default), then statistics on record
+* If `-DPRINT_DETAILS=true` is not set (the default), then statistics on record
   types are printed per system; for example:
   ```
   SMF Data for system ABCD covering Mon Dec 11 12:30:00 GMT 2023 to Mon Dec 11 14:29:59 GMT 2023
@@ -130,7 +135,7 @@ Without a plugin specified:
            120    4,801,374   99.97     1,680.77        1,236        6,116
          Total    4,802,814  100.00     1,688.82        1,236       30,204
   ```
-* If `-DPRINT_DETAILS=YES` is set, the `dump` method is called on each record as
+* If `-DPRINT_DETAILS=true` is set, the `dump` method is called on each record as
   it is processed. This will print each record header and raw record which
   is useful for developing plugins.
 

--- a/SMF-Tools/SMF_CORE/src/com/ibm/smf/format/Interpreter.java
+++ b/SMF-Tools/SMF_CORE/src/com/ibm/smf/format/Interpreter.java
@@ -1,5 +1,5 @@
 /*                                                                   */
-/* Copyright 2021 IBM Corp.                                          */
+/* Copyright 2024 IBM Corp.                                          */
 /*                                                                   */
 /* Licensed under the Apache License, Version 2.0 (the "License");   */
 /* you may not use this file except in compliance with the License.  */
@@ -26,6 +26,7 @@ import java.io.UnsupportedEncodingException;
  */
 public class Interpreter {
 
+	private static final boolean PRINT_WRAPPER = Boolean.parseBoolean(System.getProperty("PRINT_WRAPPER", "true"));
 
 	//----------------------------------------------------------------------------
 	/** Create a SmfRecord from a stream buffer.
@@ -62,7 +63,8 @@ public class Interpreter {
 	 */
 	public static void interpret(ISmfFile infile, SMFFilter a_filter) {
 
-		System.out.println("SMF file analysis starts ...");
+		if (PRINT_WRAPPER)
+			System.out.println("SMF file analysis starts ...");
 
 		while (true) {
 			try 
@@ -117,8 +119,11 @@ public class Interpreter {
 	}
 
 	a_filter.processingComplete();
-	System.out.println("");
-	System.out.println("SMF file analysis ended.");
+	
+	if (PRINT_WRAPPER) {
+		System.out.println("");
+		System.out.println("SMF file analysis ended.");
+	}
 	        
  } // Interpreter.interpret()
 

--- a/SMF-Tools/SMF_CORE/src/com/ibm/smf/format/Triplet.java
+++ b/SMF-Tools/SMF_CORE/src/com/ibm/smf/format/Triplet.java
@@ -1,5 +1,5 @@
 /*                                                                   */
-/* Copyright 2021 IBM Corp.                                          */
+/* Copyright 2024 IBM Corp.                                          */
 /*                                                                   */
 /* Licensed under the Apache License, Version 2.0 (the "License");   */
 /* you may not use this file except in compliance with the License.  */
@@ -36,12 +36,24 @@ public class Triplet {
    * @param aSmfStream Smf stream to create this instance of ServeIntervalSection from.
    */
   public Triplet(SmfStream aSmfStream) {
+	  this(aSmfStream, 4, 4, 4);
+  }
+  
+  //----------------------------------------------------------------------------
+  /** Triplet constructor from SmfStream.
+   * The instance is filled from the provided SmfStream.
+   * @param aSmfStream Smf stream to create this instance of ServeIntervalSection from.
+   * @param offsetLength Length of offset field
+   * @param lengthLength Length of length field
+   * @param countLength Length of count field
+   */
+  public Triplet(SmfStream aSmfStream, int offsetLength, int lengthLength, int countLength) {
     
-    m_offset = aSmfStream.getInteger(4);
+    m_offset = aSmfStream.getInteger(offsetLength);
     
-    m_length = aSmfStream.getInteger(4);
+    m_length = aSmfStream.getInteger(lengthLength);
     
-    m_count = aSmfStream.getInteger(4);
+    m_count = aSmfStream.getInteger(countLength);
     
   } // Triplet(...)
   
@@ -109,5 +121,10 @@ public class Triplet {
     
   } // dump(...)
   /* @L1 end */
+  
+  @Override
+	public String toString() {
+		return super.toString() + " { count: " + m_count + ", offset: " + m_offset + ", length: " + m_length + " }";
+	}
   
 } // Triplet

--- a/SMF-Tools/SMF_CORE/src/com/ibm/smf/format/types/SMFType98SubType1.java
+++ b/SMF-Tools/SMF_CORE/src/com/ibm/smf/format/types/SMFType98SubType1.java
@@ -1,0 +1,306 @@
+/*                                                                   */
+/* Copyright 2024 IBM Corp.                                          */
+/*                                                                   */
+/* Licensed under the Apache License, Version 2.0 (the "License");   */
+/* you may not use this file except in compliance with the License.  */
+/* You may obtain a copy of the License at                           */
+/*                                                                   */
+/* http://www.apache.org/licenses/LICENSE-2.0                        */
+/*                                                                   */
+/* Unless required by applicable law or agreed to in writing,        */
+/* software distributed under the License is distributed on an       */
+/* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,      */
+/* either express or implied. See the License for the specific       */
+/* language governing permissions and limitations under the License. */
+/*                                                                   */
+package com.ibm.smf.format.types;
+
+import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.List;
+
+import com.ibm.smf.format.SmfRecord;
+import com.ibm.smf.format.SmfUtil;
+import com.ibm.smf.format.Triplet;
+import com.ibm.smf.format.UnsupportedVersionException;
+
+/**
+ * https://www.ibm.com/docs/en/zos/3.1.0?topic=statistics-subtype-1-zos-supervisor
+ */
+@SuppressWarnings("unused")
+public class SMFType98SubType1 extends SmfRecord {
+	private static final boolean DEBUG = Boolean.parseBoolean(System.getProperty("DEBUG", "false"));
+	private static final boolean WARNINGS = Boolean.parseBoolean(System.getProperty("WARNINGS", "true"));
+	private static final boolean ERRORS = Boolean.parseBoolean(System.getProperty("ERRORS", "true"));
+
+	public int m_SMF98_1_UT_Avg_CpuBusy_CP;
+	public int m_SMF98_1_UT_Avg_CpuBusy_zAAP;
+	public int m_SMF98_1_UT_Avg_CpuBusy_zIIP;
+	public String m_AddressSpaceMostCPUTime_CP;
+	public String m_AddressSpaceMostCPUTime_zAAP;
+	public String m_AddressSpaceMostCPUTime_zIIP;
+
+	public SMFType98SubType1(SmfRecord aSmfRecord) throws UnsupportedVersionException, UnsupportedEncodingException {
+		super(aSmfRecord);
+
+		// SmfRecord reads up to and including SMF98STY
+		// https://www.ibm.com/docs/en/zos/3.1.0?topic=rm-record-header
+		int SMF98IND = m_stream.read();
+
+		// We don't really care to reconstitute the record parts so we'll
+		// just analyze the record parts as they stream through
+		int SMF98PartSeqNo = m_stream.read();
+		int SMF98SDSLen = m_stream.getInteger(2);
+		int SMF98SDSTripletsNum = m_stream.getInteger(2);
+
+		// Sanity check
+		if (SMF98SDSTripletsNum == 3) {
+			// Reserved
+			m_stream.skip(18);
+
+			Triplet i = new Triplet(m_stream, 4, 2, 2);
+			Triplet cs = new Triplet(m_stream, 4, 2, 2);
+			Triplet d = new Triplet(m_stream, 4, 2, 2);
+
+			if (i.count() == 1) {
+				// https://www.ibm.com/docs/en/zos/3.1.0?topic=rm-identification-section-2
+				seek(i);
+
+				String jobName = m_stream.getString(8, SmfUtil.EBCDIC);
+
+				Calendar start = readDateTime();
+
+				m_stream.skip(8);
+
+				m_stream.skip(8);
+				m_stream.skip(8);
+
+				String systemName = m_stream.getString(8, SmfUtil.EBCDIC);
+
+				// Sanity check that we're reading things right
+				if (systemName.trim().equals(m_sid.trim())) {
+					if (DEBUG)
+						System.out.println("SMFType98SubType1 system name = " + systemName);
+
+					m_stream.skip(16);
+
+					m_stream.skip(16);
+				} else {
+					if (ERRORS)
+						System.err
+								.println("ERROR: Unexpected system name " + systemName + " in the context of " + m_sid);
+
+					return;
+				}
+			} else if (i.count() > 1) {
+				if (ERRORS)
+					System.err.println("ERROR: Unexpected number of identification sections: " + i.count());
+
+				return;
+			}
+
+			// https://www.ibm.com/docs/en/zos/3.1.0?topic=rm-context-summary-section
+			if (cs.count() == 1) {
+				seek(cs);
+
+				m_stream.skip(8);
+
+				// SMF98_SubtypeInfo is an alias of the 5 subsequent fields, so we don't
+				// actually read it.
+				// This is why its offset matches SMF98_ReleaseIndex.
+				// m_stream.skip(24);
+
+				int SMF98_ReleaseIndex = m_stream.getInteger(2);
+				int SMF98_WithinReleaseIndex = m_stream.getInteger(2);
+				int SMF98_PrototypeIndex = m_stream.getInteger(2);
+				m_stream.skip(2);
+				String SMF98_Prodlevel = m_stream.getString(16, SmfUtil.EBCDIC);
+
+				m_stream.skip(8);
+				m_stream.skip(8);
+				m_stream.skip(8);
+				m_stream.skip(8);
+				m_stream.skip(16);
+				m_stream.skip(16);
+			} else if (cs.count() > 1) {
+				if (ERRORS)
+					System.err.println("ERROR: Unexpected number of context summary sections: " + cs.count());
+
+				return;
+			}
+
+			// The data section depends on the subtype:
+			// https://www.ibm.com/docs/en/zos/3.1.0?topic=sr-record-type-98-x62-workload-interaction-correlator-high-frequency-throughput-statistics
+
+			// Sanity check that we're in subtype 1
+			if (m_subtype == 1) {
+				// Subtype 1:
+				// https://www.ibm.com/docs/en/zos/3.1.0?topic=statistics-subtype-1-zos-supervisor
+				if (d.count() > 0) {
+
+					seek(d);
+
+					if (d.count() > 1) {
+						if (ERRORS)
+							// We would presumably need to first read all of the triplets and then seek
+							// around
+							System.err.println("ERROR: Not implemented");
+						return;
+					}
+
+					for (int j = 0; j < d.count(); j++) {
+						// Finally, read the subtype 1 data record:
+						// https://www.ibm.com/docs/en/zos/3.1.0?topic=supervisor-data-section
+						int tripletsCount = m_stream.getInteger(4);
+
+						// "The SMF type 98 subtype 1 data section begins with a number of triplets
+						// (SMF98_1_DataTripletsNum) for a length of SMF98_1_DataTripletsNum. Check this
+						// triplet information prior to accessing a section of the record. The "number"
+						// triplet field is the primary indication of the existence of a section.
+						if (tripletsCount > 0) {
+
+							// If the number of triplets changes, then we're dealing with a change to the
+							// SMF98 record type and that would need to be re-coded
+							if (tripletsCount == 17) {
+								int tripletsLength = m_stream.getInteger(4);
+
+								if (DEBUG)
+									System.out.println("SMFType98SubType1: triplets: " + tripletsCount);
+
+								Triplet Env = new Triplet(m_stream, 4, 2, 2);
+								Triplet SIGPGRP = new Triplet(m_stream, 4, 2, 2);
+								Triplet SIGP = new Triplet(m_stream, 4, 2, 2);
+								Triplet OTH = new Triplet(m_stream, 4, 2, 2);
+								Triplet TX = new Triplet(m_stream, 4, 2, 2);
+								Triplet ECCC = new Triplet(m_stream, 4, 2, 2);
+								Triplet MISC = new Triplet(m_stream, 4, 2, 2);
+								Triplet UT = new Triplet(m_stream, 4, 2, 2);
+								Triplet LockSpinSum = new Triplet(m_stream, 4, 2, 2);
+								Triplet LockSpinDet = new Triplet(m_stream, 4, 2, 2);
+								Triplet LockSuspendSum = new Triplet(m_stream, 4, 2, 2);
+								Triplet LockSuspendDet = new Triplet(m_stream, 4, 2, 2);
+								Triplet LockLocalCMLDet = new Triplet(m_stream, 4, 2, 2);
+								Triplet PriorityBucket = new Triplet(m_stream, 4, 2, 2);
+								Triplet Consume = new Triplet(m_stream, 4, 2, 2);
+								Triplet LockSuspendMaxDet = new Triplet(m_stream, 4, 2, 2);
+								Triplet LockSuspendMaxSum = new Triplet(m_stream, 4, 2, 2);
+
+								// Read utilization:
+								// https://www.ibm.com/docs/en/zos/3.1.0?topic=supervisor-utilization-section
+								if (UT.count() == 1) {
+									seek(UT);
+									int SMF98_1_UT_CPUs_Unparked_CP = m_stream.getInteger(4);
+									int SMF98_1_UT_CPUs_Unparked_zAAP = m_stream.getInteger(4);
+									int SMF98_1_UT_CPUs_Unparked_zIIP = m_stream.getInteger(4);
+									int SMF98_1_UT_Avg_Num_UnparkedVLs_CP = m_stream.getInteger(4);
+									int SMF98_1_UT_Avg_Num_UnparkedVLs_zAAP = m_stream.getInteger(4);
+									int SMF98_1_UT_Avg_Num_UnparkedVLs_zIIP = m_stream.getInteger(4);
+									m_SMF98_1_UT_Avg_CpuBusy_CP = m_stream.getInteger(4);
+									m_SMF98_1_UT_Avg_CpuBusy_zAAP = m_stream.getInteger(4);
+									m_SMF98_1_UT_Avg_CpuBusy_zIIP = m_stream.getInteger(4);
+								} else {
+									if (ERRORS)
+										System.err.println("ERROR: Unexpected count for utilization triplet: " + UT);
+								}
+
+								if (Consume.count() > 0) {
+									seek(Consume);
+									
+									List<AddressSpaceConsumption> interestingASCs = new ArrayList<>();
+									for (int k = 0; k < Consume.count(); k++) {
+
+										// https://www.ibm.com/docs/en/zos/3.1.0?topic=supervisor-address-space-consumption-section
+										AddressSpaceConsumption asc = new AddressSpaceConsumption();
+
+										asc.SMF98_1_Consume_ProcClass = m_stream.getInteger(2);
+										asc.SMF98_1_Consume_PriorityBucket = m_stream.getInteger(2);
+										asc.SMF98_1_Consume_SubBucket = m_stream.getInteger(2);
+										
+										m_stream.skip(2);
+										
+										// https://www.ibm.com/docs/en/zos/3.1.0?topic=supervisor-execution-efficiency-sections
+										asc.SMF98_1_Consume_ExEff = new Triplet(m_stream, 4, 2, 2);
+										
+										// https://www.ibm.com/docs/en/zos/3.1.0?topic=supervisor-work-unit-sections
+										asc.SMF98_1_Consume_WorkUnit = new Triplet(m_stream, 4, 2, 2);
+										
+										// https://www.ibm.com/docs/en/zos/3.1.0?topic=supervisor-address-space-spin-lock-sections
+										asc.SMF98_1_Consume_SpinLock = new Triplet(m_stream, 4, 2, 2);
+										
+										// Only interested in certain stats
+										if (asc.SMF98_1_Consume_PriorityBucket == -1 && asc.SMF98_1_Consume_SubBucket == -1) {
+											interestingASCs.add(asc);
+										}
+									}
+									
+									for (AddressSpaceConsumption asc : interestingASCs) {
+										if (DEBUG)
+											System.out.println("SMFType98SubType1 interesting ASC work unit = " + asc.SMF98_1_Consume_WorkUnit);
+
+										seek(asc.SMF98_1_Consume_WorkUnit);
+										for (int l = 0; l < asc.SMF98_1_Consume_WorkUnit.count(); l++) {
+											// https://www.ibm.com/docs/en/zos/3.1.0?topic=supervisor-work-unit-sections
+											int SMF98_1_WorkUnit_Type = m_stream.getInteger(2);
+											
+											m_stream.skip(2);
+											m_stream.skip(2);
+											m_stream.skip(2);
+											m_stream.skip(24);
+											
+											{
+												// https://www.ibm.com/docs/en/zos/3.1.0?topic=supervisor-address-space-information-section#smf98-1-asinfo
+												int SMF98_1_AsidInfo_ASID = m_stream.getInteger(2);
+												int SMF98_1_AsidInfo_DP = m_stream.getInteger(1);
+												int SMF98_1_AsidInfo_Flags = m_stream.getInteger(1);
+												int SMF98_1_AsidInfo_Seqnum = m_stream.getInteger(4);
+												String SMF98_1_AsidInfo_JobName = m_stream.getString(8, SmfUtil.EBCDIC);
+	
+												long SMF98_1_AsidInfo_CP_AllTaskSRB_TimeTOD = m_stream.getLong(8);
+												long SMF98_1_AsidInfo_zIIP_AllTaskSRB_TimeTOD = m_stream.getLong(8);
+												int SMF98_1_AsidInfo_CP_All_TD1EQ_CPI = m_stream.getInteger(4);
+												int SMF98_1_AsidInfo_zIIP_All_TD1EQ_CPI = m_stream.getInteger(4);
+												m_stream.skip(16);
+												
+												// Only interested in certain stats
+												if (SMF98_1_WorkUnit_Type == 1) {
+													if (DEBUG)
+														System.out.println("SMFType98SubType1 SMF98_1_AsidInfo_JobName = " + SMF98_1_AsidInfo_JobName);
+													
+													if (asc.SMF98_1_Consume_ProcClass == 0) {
+														m_AddressSpaceMostCPUTime_CP = SMF98_1_AsidInfo_JobName;
+													} else if (asc.SMF98_1_Consume_ProcClass == 2) {
+														m_AddressSpaceMostCPUTime_zAAP = SMF98_1_AsidInfo_JobName;
+													} else if (asc.SMF98_1_Consume_ProcClass == 4) {
+														m_AddressSpaceMostCPUTime_zIIP = SMF98_1_AsidInfo_JobName;
+													}
+												}
+											}
+											
+											m_stream.skip(24);
+										}
+									}
+								}
+
+							} else {
+								if (ERRORS)
+									System.err.println("ERROR: Unexpected SMF98 triplet count: " + tripletsCount);
+							}
+						}
+					}
+				}
+			} else {
+				if (WARNINGS)
+					System.err.println("WARNING: Skipping 98." + m_subtype);
+			}
+		} else {
+			if (WARNINGS)
+				System.err.println("WARNING: Triplet count unexpected: " + SMF98SDSTripletsNum);
+		}
+	}
+	
+	class AddressSpaceConsumption {
+		int SMF98_1_Consume_ProcClass, SMF98_1_Consume_PriorityBucket, SMF98_1_Consume_SubBucket;
+		Triplet SMF98_1_Consume_ExEff, SMF98_1_Consume_WorkUnit, SMF98_1_Consume_SpinLock;
+	}
+}

--- a/SMF-Tools/SMF_CORE/src/com/ibm/smf/plugins/Type98CPU.java
+++ b/SMF-Tools/SMF_CORE/src/com/ibm/smf/plugins/Type98CPU.java
@@ -1,0 +1,63 @@
+/*                                                                   */
+/* Copyright 2024 IBM Corp.                                          */
+/*                                                                   */
+/* Licensed under the Apache License, Version 2.0 (the "License");   */
+/* you may not use this file except in compliance with the License.  */
+/* You may obtain a copy of the License at                           */
+/*                                                                   */
+/* http://www.apache.org/licenses/LICENSE-2.0                        */
+/*                                                                   */
+/* Unless required by applicable law or agreed to in writing,        */
+/* software distributed under the License is distributed on an       */
+/* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,      */
+/* either express or implied. See the License for the specific       */
+/* language governing permissions and limitations under the License. */
+/*                                                                   */
+package com.ibm.smf.plugins;
+
+import com.ibm.smf.format.DefaultFilter;
+import com.ibm.smf.format.SMFFilter;
+import com.ibm.smf.format.SmfPrintStream;
+import com.ibm.smf.format.SmfRecord;
+import com.ibm.smf.format.types.SMFType98SubType1;
+import com.ibm.smf.utilities.ConversionUtilities;
+
+public class Type98CPU implements SMFFilter {
+
+	private SmfPrintStream smf_printstream = null;
+
+	@Override
+	public boolean initialize(String parms) {
+		smf_printstream = DefaultFilter.commonInitialize(parms);
+		smf_printstream.println(
+				"DateTime,LPAR,AvgCpuBusyCP,AvgCpuBusyzAAP,Avg_CpuBusy_zIIP,AddressSpaceMostCPU_CP,AddressSpaceMostCPU_zAAP,AddressSpaceMostCPU_zIIP");
+		return true;
+	}
+
+	@Override
+	public boolean preParse(SmfRecord record) {
+		return record.type() == 98 && record.subtype() == 1;
+	}
+
+	@Override
+	public SmfRecord parse(SmfRecord record) {
+		return DefaultFilter.commonParse(record);
+	}
+
+	@Override
+	public void processRecord(SmfRecord record) {
+		if (record instanceof SMFType98SubType1) {
+			SMFType98SubType1 record98 = (SMFType98SubType1) record;
+			smf_printstream.println(String.format("%1$s,%2$s,%3$d,%4$d,%5$d,%6$s,%7$s,%8$s",
+					ConversionUtilities.toString(record98.m_date), record98.m_sid, record98.m_SMF98_1_UT_Avg_CpuBusy_CP,
+					record98.m_SMF98_1_UT_Avg_CpuBusy_zAAP, record98.m_SMF98_1_UT_Avg_CpuBusy_zIIP,
+					ConversionUtilities.escapeCSV(record98.m_AddressSpaceMostCPUTime_CP),
+					ConversionUtilities.escapeCSV(record98.m_AddressSpaceMostCPUTime_zAAP),
+					ConversionUtilities.escapeCSV(record98.m_AddressSpaceMostCPUTime_zIIP)));
+		}
+	}
+
+	@Override
+	public void processingComplete() {
+	}
+}

--- a/SMF-Tools/SMF_CORE/src/com/ibm/smf/utilities/ConversionUtilities.java
+++ b/SMF-Tools/SMF_CORE/src/com/ibm/smf/utilities/ConversionUtilities.java
@@ -1,15 +1,26 @@
-package com.ibm.smf.was.plugins.utilities;
-//(C) Copyright IBM Corp. 2010 - All Rights Reserved.
-//DISCLAIMER:
-//The following source code is sample code created by IBM Corporation.
-//This sample code is provided to you solely for the purpose of assisting you
-//in the  use of  the product. The code is provided 'AS IS', without warranty or
-//condition of any kind. IBM shall not be liable for any damages arising out of your
-//use of the sample code, even if IBM has been advised of the possibility of
-//such damages.
+/*                                                                   */
+/* Copyright 2024 IBM Corp.                                          */
+/*                                                                   */
+/* Licensed under the Apache License, Version 2.0 (the "License");   */
+/* you may not use this file except in compliance with the License.  */
+/* You may obtain a copy of the License at                           */
+/*                                                                   */
+/* http://www.apache.org/licenses/LICENSE-2.0                        */
+/*                                                                   */
+/* Unless required by applicable law or agreed to in writing,        */
+/* software distributed under the License is distributed on an       */
+/* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,      */
+/* either express or implied. See the License for the specific       */
+/* language governing permissions and limitations under the License. */
+/*                                                                   */
+package com.ibm.smf.utilities;
 
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.TimeZone;
 
 /**
  * A set of utilities used by various plugin routines to get 
@@ -198,5 +209,27 @@ public class ConversionUtilities
   }
  }
  
+ private static DateFormat formatter;
+
+	public static String toString(Date date) {
+		if (formatter == null) {
+			String dtf = System.getProperty("com.ibm.ws390.smf.dateTimeFormat");
+			if (dtf != null) {
+				formatter = new SimpleDateFormat(dtf);
+			} else {
+				formatter = DateFormat.getDateTimeInstance(DateFormat.FULL, DateFormat.FULL);
+			}
+
+			TimeZone tz = TimeZone.getTimeZone("GMT");
+			formatter.setTimeZone(tz);
+		}
+
+		return formatter.format(date);
+	}
+	
+	public static String escapeCSV(String str) {
+		if (str == null) return "";
+		return str.replaceAll("\"", "\\\"");
+	}
 }
 

--- a/SMF-Tools/SMF_CORE/src/com/ibm/smf/utilities/STCK.java
+++ b/SMF-Tools/SMF_CORE/src/com/ibm/smf/utilities/STCK.java
@@ -14,7 +14,7 @@
 /* language governing permissions and limitations under the License. */
 /*                                                                   */
 
-package com.ibm.smf.was.plugins.utilities;
+package com.ibm.smf.utilities;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
@@ -33,7 +33,6 @@ public class STCK
    * Calculate and remember the origin difference between Java and the MVS time
    */
   public final static long JAVA_MVS_ORIGIN_DIFFERENCE = calculateClockOriginDifference();
-  private static DateFormat formatter;
 
   private static long calculateClockOriginDifference() {
       Calendar calendar = Calendar.getInstance();
@@ -121,21 +120,10 @@ public class STCK
 	   // Add the timestamp to the origin difference and convert
 	   Date date = new Date(millis + JAVA_MVS_ORIGIN_DIFFERENCE);
 
-	   if (formatter == null) {
-		   String dtf = System.getProperty("com.ibm.ws390.smf.dateTimeFormat");
-		    if (dtf!=null){
-		    	formatter = new SimpleDateFormat(dtf);
-		    } else {
-		    	formatter = DateFormat.getDateTimeInstance(DateFormat.FULL,DateFormat.FULL); 	
-		    }
-
-		   TimeZone tz = TimeZone.getTimeZone("GMT");
-		   formatter.setTimeZone(tz);
-	   }
-	   
-	   return formatter.format(date);
-	  
+	   return ConversionUtilities.toString(date);
   }
+
+
   
   /**
    * Converts a String format STCK timestamp into a java.util.Date 

--- a/SMF-Tools/SMF_WAS_PLUGINS/src/com/ibm/smf/was/plugins/AffinityCreation.java
+++ b/SMF-Tools/SMF_WAS_PLUGINS/src/com/ibm/smf/was/plugins/AffinityCreation.java
@@ -1,5 +1,5 @@
 /*                                                                   */
-/* Copyright 2021 IBM Corp.                                          */
+/* Copyright 2024 IBM Corp.                                          */
 /*                                                                   */
 /* Licensed under the Apache License, Version 2.0 (the "License");   */
 /* you may not use this file except in compliance with the License.  */
@@ -31,8 +31,8 @@ import com.ibm.smf.format.Triplet;
 import com.ibm.smf.twas.request.RequestActivitySmfRecord;
 import com.ibm.smf.twas.request.ZosRequestInfoSection;
 import com.ibm.smf.was.common.WASConstants;
-import com.ibm.smf.was.plugins.utilities.ConversionUtilities;
-import com.ibm.smf.was.plugins.utilities.STCK;
+import com.ibm.smf.utilities.ConversionUtilities;
+import com.ibm.smf.utilities.STCK;
 
 
 /**

--- a/SMF-Tools/SMF_WAS_PLUGINS/src/com/ibm/smf/was/plugins/AffinityReport.java
+++ b/SMF-Tools/SMF_WAS_PLUGINS/src/com/ibm/smf/was/plugins/AffinityReport.java
@@ -1,5 +1,5 @@
 /*                                                                   */
-/* Copyright 2021 IBM Corp.                                          */
+/* Copyright 2024 IBM Corp.                                          */
 /*                                                                   */
 /* Licensed under the Apache License, Version 2.0 (the "License");   */
 /* you may not use this file except in compliance with the License.  */
@@ -31,8 +31,8 @@ import com.ibm.smf.twas.request.ZosRequestInfoSection;
 import com.ibm.smf.was.common.ClassificationDataSection;
 import com.ibm.smf.was.common.PlatformNeutralSection;
 import com.ibm.smf.was.common.WASConstants;
-import com.ibm.smf.was.plugins.utilities.ConversionUtilities;
-import com.ibm.smf.was.plugins.utilities.STCK;
+import com.ibm.smf.utilities.ConversionUtilities;
+import com.ibm.smf.utilities.STCK;
 
 
 

--- a/SMF-Tools/SMF_WAS_PLUGINS/src/com/ibm/smf/was/plugins/AsyncCSVExport.java
+++ b/SMF-Tools/SMF_WAS_PLUGINS/src/com/ibm/smf/was/plugins/AsyncCSVExport.java
@@ -1,5 +1,5 @@
 /*                                                                   */
-/* Copyright 2021 IBM Corp.                                          */
+/* Copyright 2024 IBM Corp.                                          */
 /*                                                                   */
 /* Licensed under the Apache License, Version 2.0 (the "License");   */
 /* you may not use this file except in compliance with the License.  */
@@ -28,8 +28,8 @@ import com.ibm.smf.twas.request.RequestActivitySmfRecord;
 import com.ibm.smf.was.common.PlatformNeutralSection;
 import com.ibm.smf.was.common.WASConstants;
 import com.ibm.smf.was.common.ZosServerInfoSection;
-import com.ibm.smf.was.plugins.utilities.ConversionUtilities;
-import com.ibm.smf.was.plugins.utilities.STCK;
+import com.ibm.smf.utilities.ConversionUtilities;
+import com.ibm.smf.utilities.STCK;
 
 /**
  * 

--- a/SMF-Tools/SMF_WAS_PLUGINS/src/com/ibm/smf/was/plugins/CSVExport.java
+++ b/SMF-Tools/SMF_WAS_PLUGINS/src/com/ibm/smf/was/plugins/CSVExport.java
@@ -1,5 +1,5 @@
 /*                                                                   */
-/* Copyright 2021 IBM Corp.                                          */
+/* Copyright 2024 IBM Corp.                                          */
 /*                                                                   */
 /* Licensed under the Apache License, Version 2.0 (the "License");   */
 /* you may not use this file except in compliance with the License.  */
@@ -32,8 +32,8 @@ import com.ibm.smf.was.common.ClassificationDataSection;
 import com.ibm.smf.was.common.PlatformNeutralSection;
 import com.ibm.smf.was.common.WASConstants;
 import com.ibm.smf.was.common.ZosServerInfoSection;
-import com.ibm.smf.was.plugins.utilities.ConversionUtilities;
-import com.ibm.smf.was.plugins.utilities.STCK;
+import com.ibm.smf.utilities.ConversionUtilities;
+import com.ibm.smf.utilities.STCK;
 /**
  * 
  * Export data to comma separated value file

--- a/SMF-Tools/SMF_WAS_PLUGINS/src/com/ibm/smf/was/plugins/DispatchThreadUsage.java
+++ b/SMF-Tools/SMF_WAS_PLUGINS/src/com/ibm/smf/was/plugins/DispatchThreadUsage.java
@@ -1,5 +1,5 @@
 /*                                                                   */
-/* Copyright 2021 IBM Corp.                                          */
+/* Copyright 2024 IBM Corp.                                          */
 /*                                                                   */
 /* Licensed under the Apache License, Version 2.0 (the "License");   */
 /* you may not use this file except in compliance with the License.  */
@@ -33,8 +33,8 @@ import com.ibm.smf.twas.request.RequestActivitySmfRecord;
 import com.ibm.smf.twas.request.ZosRequestInfoSection;
 import com.ibm.smf.was.common.PlatformNeutralSection;
 import com.ibm.smf.was.common.WASConstants;
-import com.ibm.smf.was.plugins.utilities.ConversionUtilities;
-import com.ibm.smf.was.plugins.utilities.STCK;
+import com.ibm.smf.utilities.ConversionUtilities;
+import com.ibm.smf.utilities.STCK;
 
 public class DispatchThreadUsage implements SMFFilter {
 

--- a/SMF-Tools/SMF_WAS_PLUGINS/src/com/ibm/smf/was/plugins/FindHighWaterInQueue.java
+++ b/SMF-Tools/SMF_WAS_PLUGINS/src/com/ibm/smf/was/plugins/FindHighWaterInQueue.java
@@ -1,5 +1,5 @@
 /*                                                                   */
-/* Copyright 2021 IBM Corp.                                          */
+/* Copyright 2024 IBM Corp.                                          */
 /*                                                                   */
 /* Licensed under the Apache License, Version 2.0 (the "License");   */
 /* you may not use this file except in compliance with the License.  */
@@ -31,7 +31,8 @@ import com.ibm.smf.twas.request.RequestActivitySmfRecord;
 import com.ibm.smf.twas.request.ZosRequestInfoSection;
 import com.ibm.smf.was.common.PlatformNeutralSection;
 import com.ibm.smf.was.common.WASConstants;
-import com.ibm.smf.was.plugins.utilities.ConversionUtilities;
+import com.ibm.smf.utilities.ConversionUtilities;
+import com.ibm.smf.utilities.STCK;
 
 public class FindHighWaterInQueue implements SMFFilter {
 

--- a/SMF-Tools/SMF_WAS_PLUGINS/src/com/ibm/smf/was/plugins/LibertyBatchExport.java
+++ b/SMF-Tools/SMF_WAS_PLUGINS/src/com/ibm/smf/was/plugins/LibertyBatchExport.java
@@ -1,5 +1,5 @@
 /*                                                                   */
-/* Copyright 2021 IBM Corp.                                          */
+/* Copyright 2024 IBM Corp.                                          */
 /*                                                                   */
 /* Licensed under the Apache License, Version 2.0 (the "License");   */
 /* you may not use this file except in compliance with the License.  */
@@ -31,7 +31,8 @@ import com.ibm.smf.liberty.batch.LibertyBatchReferenceNamesSection;
 import com.ibm.smf.liberty.batch.LibertyBatchSubsystemSection;
 import com.ibm.smf.liberty.batch.LibertyBatchUssSection;
 import com.ibm.smf.was.common.WASConstants;
-import com.ibm.smf.was.plugins.utilities.ConversionUtilities;
+import com.ibm.smf.utilities.ConversionUtilities;
+import com.ibm.smf.utilities.STCK;
 
 
 /**

--- a/SMF-Tools/SMF_WAS_PLUGINS/src/com/ibm/smf/was/plugins/LibertyExport.java
+++ b/SMF-Tools/SMF_WAS_PLUGINS/src/com/ibm/smf/was/plugins/LibertyExport.java
@@ -1,5 +1,5 @@
 /*                                                                   */
-/* Copyright 2021 IBM Corp.                                          */
+/* Copyright 2024 IBM Corp.                                          */
 /*                                                                   */
 /* Licensed under the Apache License, Version 2.0 (the "License");   */
 /* you may not use this file except in compliance with the License.  */
@@ -29,8 +29,8 @@ import com.ibm.smf.liberty.request.LibertyRequestRecord;
 import com.ibm.smf.liberty.request.LibertyServerInfoSection;
 import com.ibm.smf.was.common.ClassificationDataSection;
 import com.ibm.smf.was.common.WASConstants;
-import com.ibm.smf.was.plugins.utilities.ConversionUtilities;
-import com.ibm.smf.was.plugins.utilities.STCK;
+import com.ibm.smf.utilities.ConversionUtilities;
+import com.ibm.smf.utilities.STCK;
 
 
 /**

--- a/SMF-Tools/SMF_WAS_PLUGINS/src/com/ibm/smf/was/plugins/LibertyResponseTimes.java
+++ b/SMF-Tools/SMF_WAS_PLUGINS/src/com/ibm/smf/was/plugins/LibertyResponseTimes.java
@@ -1,5 +1,5 @@
 /*                                                                   */
-/* Copyright 2021 IBM Corp.                                          */
+/* Copyright 2024 IBM Corp.                                          */
 /*                                                                   */
 /* Licensed under the Apache License, Version 2.0 (the "License");   */
 /* you may not use this file except in compliance with the License.  */
@@ -30,7 +30,8 @@ import com.ibm.smf.liberty.request.LibertyRequestInfoSection;
 import com.ibm.smf.liberty.request.LibertyRequestRecord;
 import com.ibm.smf.was.common.ClassificationDataSection;
 import com.ibm.smf.was.common.WASConstants;
-import com.ibm.smf.was.plugins.utilities.ConversionUtilities;
+import com.ibm.smf.utilities.ConversionUtilities;
+import com.ibm.smf.utilities.STCK;
 
 public class LibertyResponseTimes implements SMFFilter {
 	

--- a/SMF-Tools/SMF_WAS_PLUGINS/src/com/ibm/smf/was/plugins/RequestDensity.java
+++ b/SMF-Tools/SMF_WAS_PLUGINS/src/com/ibm/smf/was/plugins/RequestDensity.java
@@ -1,5 +1,5 @@
 /*                                                                   */
-/* Copyright 2021 IBM Corp.                                          */
+/* Copyright 2024 IBM Corp.                                          */
 /*                                                                   */
 /* Licensed under the Apache License, Version 2.0 (the "License");   */
 /* you may not use this file except in compliance with the License.  */
@@ -29,8 +29,8 @@ import com.ibm.smf.format.Triplet;
 import com.ibm.smf.twas.request.RequestActivitySmfRecord;
 import com.ibm.smf.twas.request.ZosRequestInfoSection;
 import com.ibm.smf.was.common.WASConstants;
-import com.ibm.smf.was.plugins.utilities.ConversionUtilities;
-import com.ibm.smf.was.plugins.utilities.STCK;
+import com.ibm.smf.utilities.ConversionUtilities;
+import com.ibm.smf.utilities.STCK;
 
 
 /**

--- a/SMF-Tools/SMF_WAS_PLUGINS/src/com/ibm/smf/was/plugins/RequestDensity2.java
+++ b/SMF-Tools/SMF_WAS_PLUGINS/src/com/ibm/smf/was/plugins/RequestDensity2.java
@@ -1,5 +1,5 @@
 /*                                                                   */
-/* Copyright 2021 IBM Corp.                                          */
+/* Copyright 2024 IBM Corp.                                          */
 /*                                                                   */
 /* Licensed under the Apache License, Version 2.0 (the "License");   */
 /* you may not use this file except in compliance with the License.  */
@@ -30,8 +30,8 @@ import com.ibm.smf.format.Triplet;
 import com.ibm.smf.twas.request.RequestActivitySmfRecord;
 import com.ibm.smf.twas.request.ZosRequestInfoSection;
 import com.ibm.smf.was.common.WASConstants;
-import com.ibm.smf.was.plugins.utilities.ConversionUtilities;
-import com.ibm.smf.was.plugins.utilities.STCK;
+import com.ibm.smf.utilities.ConversionUtilities;
+import com.ibm.smf.utilities.STCK;
 
 
 /**

--- a/SMF-Tools/SMF_WAS_PLUGINS/src/com/ibm/smf/was/plugins/RequestsPerServer.java
+++ b/SMF-Tools/SMF_WAS_PLUGINS/src/com/ibm/smf/was/plugins/RequestsPerServer.java
@@ -1,5 +1,5 @@
 /*                                                                   */
-/* Copyright 2021 IBM Corp.                                          */
+/* Copyright 2024 IBM Corp.                                          */
 /*                                                                   */
 /* Licensed under the Apache License, Version 2.0 (the "License");   */
 /* you may not use this file except in compliance with the License.  */
@@ -32,8 +32,8 @@ import com.ibm.smf.twas.request.ZosRequestInfoSection;
 import com.ibm.smf.was.common.PlatformNeutralSection;
 import com.ibm.smf.was.common.WASConstants;
 import com.ibm.smf.was.common.ZosServerInfoSection;
-import com.ibm.smf.was.plugins.utilities.ConversionUtilities;
-import com.ibm.smf.was.plugins.utilities.STCK;
+import com.ibm.smf.utilities.ConversionUtilities;
+import com.ibm.smf.utilities.STCK;
 
 
 /**

--- a/SMF-Tools/SMF_WAS_PLUGINS/src/com/ibm/smf/was/plugins/ResponseTimes.java
+++ b/SMF-Tools/SMF_WAS_PLUGINS/src/com/ibm/smf/was/plugins/ResponseTimes.java
@@ -1,5 +1,5 @@
 /*                                                                   */
-/* Copyright 2021 IBM Corp.                                          */
+/* Copyright 2024 IBM Corp.                                          */
 /*                                                                   */
 /* Licensed under the Apache License, Version 2.0 (the "License");   */
 /* you may not use this file except in compliance with the License.  */
@@ -35,8 +35,8 @@ import com.ibm.smf.twas.request.RequestActivitySmfRecord;
 import com.ibm.smf.twas.request.ZosRequestInfoSection;
 import com.ibm.smf.was.common.ClassificationDataSection;
 import com.ibm.smf.was.common.WASConstants;
-import com.ibm.smf.was.plugins.utilities.ConversionUtilities;
-import com.ibm.smf.was.plugins.utilities.STCK;
+import com.ibm.smf.utilities.ConversionUtilities;
+import com.ibm.smf.utilities.STCK;
 
 /**
  * Reports on response and CPU times for the SMF data provided

--- a/SMF-Tools/SMF_WAS_PLUGINS/src/com/ibm/smf/was/plugins/ThreadRequestDensity.java
+++ b/SMF-Tools/SMF_WAS_PLUGINS/src/com/ibm/smf/was/plugins/ThreadRequestDensity.java
@@ -1,5 +1,5 @@
 /*                                                                   */
-/* Copyright 2021 IBM Corp.                                          */
+/* Copyright 2024 IBM Corp.                                          */
 /*                                                                   */
 /* Licensed under the Apache License, Version 2.0 (the "License");   */
 /* you may not use this file except in compliance with the License.  */
@@ -35,8 +35,8 @@ import com.ibm.smf.twas.request.RequestActivitySmfRecord;
 import com.ibm.smf.twas.request.ZosRequestInfoSection;
 import com.ibm.smf.was.common.PlatformNeutralSection;
 import com.ibm.smf.was.common.WASConstants;
-import com.ibm.smf.was.plugins.utilities.ConversionUtilities;
-import com.ibm.smf.was.plugins.utilities.STCK;
+import com.ibm.smf.utilities.ConversionUtilities;
+import com.ibm.smf.utilities.STCK;
 
 
 /**

--- a/SMF-Tools/SMF_WAS_PLUGINS/src/com/ibm/smf/was/plugins/ThreadRequestDensity2.java
+++ b/SMF-Tools/SMF_WAS_PLUGINS/src/com/ibm/smf/was/plugins/ThreadRequestDensity2.java
@@ -1,5 +1,5 @@
 /*                                                                   */
-/* Copyright 2021 IBM Corp.                                          */
+/* Copyright 2024 IBM Corp.                                          */
 /*                                                                   */
 /* Licensed under the Apache License, Version 2.0 (the "License");   */
 /* you may not use this file except in compliance with the License.  */
@@ -35,8 +35,8 @@ import com.ibm.smf.twas.request.RequestActivitySmfRecord;
 import com.ibm.smf.twas.request.ZosRequestInfoSection;
 import com.ibm.smf.was.common.PlatformNeutralSection;
 import com.ibm.smf.was.common.WASConstants;
-import com.ibm.smf.was.plugins.utilities.ConversionUtilities;
-import com.ibm.smf.was.plugins.utilities.STCK;
+import com.ibm.smf.utilities.ConversionUtilities;
+import com.ibm.smf.utilities.STCK;
 
 
 // Different from ThreadRequestDensity because it uses the dispatch end time instead of start.


### PR DESCRIPTION
Most of the new code is in SMFType98SubType1.java and Type98CPU.java (discussed with Dave and he agreed it made sense to put this into the `smfcore` project as 98.1 supervisor records are "core" z/OS); however, also made some other changes:

* Moved some utility classes from the WAS project into core.
* Some other refactoring that was useful such as common code to parse a date/time.
* Ignore Eclipse `.settings` directories.
* Add `-DPRINT_WRAPPER=false` support to get a clean CSV if desired.
* Fix `-DPRINT_DETAILS=` usage documentation.