### PR TITLE
Handle extra com.ibm.smf.format.SMF argument

### DIFF
--- a/SMF-Tools/SMF_CORE/src/com/ibm/smf/format/SMF.java
+++ b/SMF-Tools/SMF_CORE/src/com/ibm/smf/format/SMF.java
@@ -1,5 +1,5 @@
 /*                                                                   */
-/* Copyright 2021 IBM Corp.                                          */
+/* Copyright 2024 IBM Corp.                                          */
 /*                                                                   */
 /* Licensed under the Apache License, Version 2.0 (the "License");   */
 /* you may not use this file except in compliance with the License.  */
@@ -48,7 +48,7 @@ public class SMF
   {
    System.out.println("Specify INFILE(dataset.name) to process an SMF dump dataset");
    System.out.println("Specify PLUGIN(class,parms) to run an alternate plugin");
-   System.out.println("The default is PLUGIN(DEFAULT,STDOUT");
+   System.out.println("The default is PLUGIN(DEFAULT,STDOUT)");
    System.out.println("Additional documentation, license information, source code,");
    System.out.println("and javadoc may be found inside this .jar file");
    return;
@@ -56,6 +56,9 @@ public class SMF
   for (int i=0;i<args.length;++i)
   {
    String parm = args[i];
+   if ("com.ibm.smf.format.SMF".equals(parm)) {
+	   continue;
+   }
    int openpren=parm.indexOf("(");
    int closepren = parm.indexOf(")");
    


### PR DESCRIPTION
Since the change to building with Maven in b040e60, the JAR is now self-executable and specifies the main class com.ibm.smf.format.SMF meaning that when executing with -jar, specifying the class name is not needed. However, a lot of examples still show this sort of execution. Running with the class name as the first argument will cause an error because all arguments are expected to have parentheses. Therefore, this commit allows for an extra com.ibm.smf.format.SMF argument which is simply ignored. Things will work the same as before if the user is running without an executable JAR and instead puts a packaged JAR on the classpath.