### PR TITLE
Allow multiple INFILEs for com.ibm.smf.format.SMF

### DIFF
--- a/SMF-Tools/SMF_CORE/src/com/ibm/smf/format/SMF.java
+++ b/SMF-Tools/SMF_CORE/src/com/ibm/smf/format/SMF.java
@@ -16,140 +16,120 @@
 
 package com.ibm.smf.format;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * The main class to use to parse SMF records with this browser
  * 
  */
-public class SMF 
-{
+public class SMF {
 
- private static ISmfFile m_file = null;
- private static SMFFilter filter = null;
- 
- /**
-  * The main method
-  * @param args The standard input array of strings.  May contain two strings consisting
-  * of INFILE(input file name) and PLUGIN(class,parms).
-  */
- public static void main(String[] args) 
- { 
-  boolean foundINFILE = false;
-  boolean foundPLUGIN = false;
-  
-  // No parms?  Asking for help?  
-  if ((args.length==0)||
-	  ((args.length==1)&&
-	   (
-	    (args[0].equalsIgnoreCase("-help"))||
-	    (args[0].equalsIgnoreCase("-?"))
-	   )
-	  )
-	 ) 
-  {
-   System.out.println("Specify INFILE(dataset.name) to process an SMF dump dataset");
-   System.out.println("Specify PLUGIN(class,parms) to run an alternate plugin");
-   System.out.println("The default is PLUGIN(DEFAULT,STDOUT)");
-   System.out.println("Additional documentation, license information, source code,");
-   System.out.println("and javadoc may be found inside this .jar file");
-   return;
-  }
-  for (int i=0;i<args.length;++i)
-  {
-   String parm = args[i];
-   if ("com.ibm.smf.format.SMF".equals(parm)) {
-	   continue;
-   }
-   int openpren=parm.indexOf("(");
-   int closepren = parm.indexOf(")");
-   
-   if ((openpren==-1)|(closepren==-1))
-   {
-	System.out.println("Must specify keywords with values in parenthesis");
-	return;
-   }
-   String keyword = parm.substring(0,openpren);
-   String value = parm.substring(openpren+1,closepren);
-   if ((keyword==null)|(keyword.length()==0))
-   {
-    System.out.println("Must specify keywords with values in parenthesis");
-    return;
-   }
-   if ((value==null)|value.length()==0)
-   {
-	System.out.println("Keyword values must be greater than zero length");
-	return;
-   }
-   
-   if ((keyword.equalsIgnoreCase("INFILE"))& (foundINFILE==false))
-   {
-    foundINFILE=true;
+	/**
+	 * The main method
+	 * 
+	 * @param args The standard input array of strings. May contain strings
+	 *             consisting of INFILE(input file name) and PLUGIN(class,parms).
+	 */
+	public static void main(String[] args) {
+		boolean foundINFILE = false;
+		boolean foundPLUGIN = false;
+		SMFFilter filter = null;
 
-	try 
-	{
-	 m_file = new JzOSSmfFile();
-	 m_file.open(value);
-	} 
-	catch (Exception e) 
-	{
-	 System.out.println(" Exception during open " + value);
-	 System.out.println(" Exception data:\n" + e.toString());
-	 return;
-	}    	
-   }
-   
-   if ((keyword.equalsIgnoreCase("PLUGIN"))& (foundPLUGIN==false))
-   {
-    foundPLUGIN=true;
-    try
-    {
-     int commaloc = value.indexOf(",");
-     if (commaloc==-1)
-     {
-      System.out.println("PLUGIN keyword requires class and parm string separated by comma");
-      return;
-     }
-     String classname = value.substring(0,commaloc);
-     String parmstring = value.substring(commaloc+1);
-     if ((classname.length()==0)|(parmstring.length()==0))
-     {
-      System.out.println("classname and parm string must be non-zero length");
-      return;
-     }
-     
-     if (classname.equals("DEFAULT"))
-    	 classname = "com.ibm.smf.format.DefaultFilter";
-     Class filterclass = Class.forName(classname);
-     filter = (SMFFilter)filterclass.newInstance();
-     boolean result = filter.initialize(parmstring);
-     if (result==false)
-     {
-      System.out.println("plugin initialization failed..terminating");
-      return;
-     }
-    }
-    catch (Exception e)
-    {
-     System.out.println("Exception loading class "+value);
-     System.out.println(e.toString());
-     return;
-    }
-   } 
-  } // end loop
-  
-  if (foundPLUGIN==false) 
-  {
-   filter = new DefaultFilter();
-   filter.initialize("STDOUT");
-  }
-  
-  if (foundINFILE==false)
-  {
-   System.out.println("Must specify an input file via INFILE");
-   return;
-  }
-  
-    Interpreter.interpret(m_file, filter);
-  
- }
+		// No parms? Asking for help?
+		if ((args.length == 0)
+				|| ((args.length == 1) && ((args[0].equalsIgnoreCase("-help")) || (args[0].equalsIgnoreCase("-?"))))) {
+			System.out.println("Specify INFILE(dataset.name) to process one or more SMF dump datasets");
+			System.out.println("Specify PLUGIN(class,parms) to run an alternate plugin");
+			System.out.println("The default is PLUGIN(DEFAULT,STDOUT)");
+			System.out.println("Additional documentation, license information, source code,");
+			System.out.println("and javadoc may be found inside this .jar file");
+			return;
+		}
+		List<ISmfFile> files = new ArrayList<>();
+		for (int i = 0; i < args.length; ++i) {
+			String parm = args[i];
+			if ("com.ibm.smf.format.SMF".equals(parm)) {
+				continue;
+			}
+			int openpren = parm.indexOf("(");
+			int closepren = parm.indexOf(")");
+
+			if ((openpren == -1) | (closepren == -1)) {
+				System.out.println("Must specify keywords with values in parenthesis");
+				return;
+			}
+			String keyword = parm.substring(0, openpren);
+			String value = parm.substring(openpren + 1, closepren);
+			if ((keyword == null) | (keyword.length() == 0)) {
+				System.out.println("Must specify keywords with values in parenthesis");
+				return;
+			}
+			if ((value == null) | value.length() == 0) {
+				System.out.println("Keyword values must be greater than zero length");
+				return;
+			}
+
+			if (keyword.equalsIgnoreCase("INFILE")) {
+				foundINFILE = true;
+
+				try {
+					ISmfFile file = new JzOSSmfFile();
+					file.open(value);
+					files.add(file);
+				} catch (Exception e) {
+					System.out.println(" Exception during open " + value);
+					System.out.println(" Exception data:\n" + e.toString());
+					return;
+				}
+			}
+
+			if ((keyword.equalsIgnoreCase("PLUGIN")) & (foundPLUGIN == false)) {
+				foundPLUGIN = true;
+				try {
+					int commaloc = value.indexOf(",");
+					if (commaloc == -1) {
+						System.out.println("PLUGIN keyword requires class and parm string separated by comma");
+						return;
+					}
+					String classname = value.substring(0, commaloc);
+					String parmstring = value.substring(commaloc + 1);
+					if ((classname.length() == 0) | (parmstring.length() == 0)) {
+						System.out.println("classname and parm string must be non-zero length");
+						return;
+					}
+
+					if (classname.equals("DEFAULT"))
+						classname = "com.ibm.smf.format.DefaultFilter";
+					Class filterclass = Class.forName(classname);
+					filter = (SMFFilter) filterclass.newInstance();
+					boolean result = filter.initialize(parmstring);
+					if (result == false) {
+						System.out.println("plugin initialization failed..terminating");
+						return;
+					}
+				} catch (Exception e) {
+					System.out.println("Exception loading class " + value);
+					System.out.println(e.toString());
+					return;
+				}
+			}
+		} // end loop
+
+		if (foundPLUGIN == false) {
+			filter = new DefaultFilter();
+			filter.initialize("STDOUT");
+		}
+
+		if (foundINFILE == false) {
+			System.out.println("Must specify at least one input file via INFILE");
+			return;
+		}
+		
+		for (ISmfFile file : files) {
+			Interpreter.interpret(file, filter, false);
+		}
+		
+		Interpreter.performFilterCompletion(filter);
+	}
 }
-

--- a/SMF-Tools/SMF_WAS_PLUGINS/src/com/ibm/smf/was/plugins/ResponseTimes.java
+++ b/SMF-Tools/SMF_WAS_PLUGINS/src/com/ibm/smf/was/plugins/ResponseTimes.java
@@ -141,6 +141,7 @@ public class ResponseTimes implements SMFFilter {
 	@Override
 	public void processRecord(SmfRecord record) {
 	     // cast to a subtype 9 and declare generic variables
+		if (record instanceof RequestActivitySmfRecord) {
 		 RequestActivitySmfRecord rec = (RequestActivitySmfRecord)record;
 		 Triplet zOSRequestTriplet;
 		 int sectionCount;
@@ -267,7 +268,7 @@ public class ResponseTimes implements SMFFilter {
 		 urid.update(responseTime, queueTime, dispatchTime, cpuTime,offloadCpu,bytesReceived,bytesSent);
 	     
          ++totalRequests;
-		
+		}
 	}
 	
 	private Map<String, URIData> getTable(String breakdownKey, long receiveTime, long queuedTime, long dispatchStart, long dispatchEnd, long responded) {


### PR DESCRIPTION
It's common for administrators to provide SMF data across multiple data sets due to size constraints, so this adds the ability to run the same PLUGIN across multiple INFILE data sets. The change is pretty small but the diff is relatively big because I could no longer handle the strange formatting so I performed a format on the whole files through Eclipse, so there are a lot of whitespace changes; however, the actual changes are pretty simple:

1. In SMF.main, add all INFILEs to an ArrayList and then iterate over that list and call Interpreter.interpret for each.
2. Add an optional boolean parameter to Interpreter.interpret to specify whether or not to run processingComplete on the filter at the end of the interpret method. This defaults to true to match the old behavior (e.g. used by JclSmf).
3. Update SMF.main to pass false to Interpreter.interpret and then call Interpreter.performFilterCompletion after all files have been processed.

The commit also includes a minor bug fix for the ResponseTimes plugin when there are non-120 records.