### PR TITLE
WAS ResponseTimes: Disaggregate non-HTTP response times

### DIFF
--- a/SMF-Tools/SMF_WAS/src/com/ibm/smf/twas/request/PlatformNeutralRequestInfoSection.java
+++ b/SMF-Tools/SMF_WAS/src/com/ibm/smf/twas/request/PlatformNeutralRequestInfoSection.java
@@ -1,5 +1,5 @@
 /*                                                                   */
-/* Copyright 2021 IBM Corp.                                          */
+/* Copyright 2025 IBM Corp.                                          */
 /*                                                                   */
 /* Licensed under the Apache License, Version 2.0 (the "License");   */
 /* you may not use this file except in compliance with the License.  */

--- a/SMF-Tools/SMF_WAS/src/com/ibm/smf/twas/request/PlatformNeutralRequestInfoSection.java
+++ b/SMF-Tools/SMF_WAS/src/com/ibm/smf/twas/request/PlatformNeutralRequestInfoSection.java
@@ -110,6 +110,39 @@ import com.ibm.smf.format.UnsupportedVersionException;
       return s_supportedVersion;
       
     } // supportedVersion()
+    
+    public String getRequestTypeString() {
+    	switch (m_requestType) {
+    	case TypeUnknown:
+    		return "Unknown";
+    	case TypeIIOP:
+    		return "IIOP";
+    	case TypeHTTP:
+    		return "HTTP";
+    	case TypeHTTPS:
+    		return "HTTPS";
+    	case TypeMDBA:
+    		return "MDBA";
+    	case TypeMDBB:
+    		return "MDBB";
+    	case TypeMDBC:
+    		return "MDBC";
+    	case TypeSIP:
+    		return "SIP";
+    	case TypeSIPS:
+    		return "SIPS";
+    	case TypeMBean:
+    		return "MBean";
+    	case TypeOTS:
+    		return "OTS";
+    	case TypeOther:
+    		return "Other";
+    	case TypeOLA:
+    		return "OLA";
+		default:
+			return "MissingCase";
+    	}
+    }
 
 
     //----------------------------------------------------------------------------

--- a/SMF-Tools/SMF_WAS_PLUGINS/src/com/ibm/smf/was/plugins/ResponseTimes.java
+++ b/SMF-Tools/SMF_WAS_PLUGINS/src/com/ibm/smf/was/plugins/ResponseTimes.java
@@ -1,5 +1,5 @@
 /*                                                                   */
-/* Copyright 2024 IBM Corp.                                          */
+/* Copyright 2025 IBM Corp.                                          */
 /*                                                                   */
 /* Licensed under the Apache License, Version 2.0 (the "License");   */
 /* you may not use this file except in compliance with the License.  */

--- a/SMF-Tools/SMF_WAS_PLUGINS/src/com/ibm/smf/was/plugins/ResponseTimes.java
+++ b/SMF-Tools/SMF_WAS_PLUGINS/src/com/ibm/smf/was/plugins/ResponseTimes.java
@@ -162,6 +162,7 @@ public class ResponseTimes implements SMFFilter {
 		 }
 
 		 // From the Platform Neutral Request Info Section
+		 String requestTypeString = null;
 		 zOSRequestTriplet = rec.m_platformNeutralRequestInfoTriplet;
 		 sectionCount = zOSRequestTriplet.count();
 		 if (sectionCount > 0)
@@ -173,6 +174,8 @@ public class ResponseTimes implements SMFFilter {
 	      
 	      // Accumulate CPU time in milliseconds
 	      cpuTime = sec.m_dispatchTcbCpu/1000;
+	      
+	      requestTypeString = sec.getRequestTypeString();
 		 }
 		 
 		 String breakdownKey = null;
@@ -234,6 +237,10 @@ public class ResponseTimes implements SMFFilter {
 	            	uri = cds.m_theData;
 	            } 
 	    	 }
+	     }
+	     
+	     if (uri == null && requestTypeString != null) {
+	    	 uri = requestTypeString;
 	     }
 	     
 		 // From the network section


### PR DESCRIPTION
Confirmed that Dave is happy with this.

Previously, for ResponseTimes, non-HTTP work would be aggregated together into a `null` URI column. Instead, what this PR does is if it's non-HTTP work, then it sets the "URI" to the type of work (e.g. IIOP, MDB, etc.). This way we get response times disaggregated by the type of non-HTTP work and then this makes it easier to throw into a pivot table to break down response times of EJBs vs MDBs, etc.

Example output:

```
$ java -Xmx1g "-Dcom.ibm.ws390.smf.dateTimeFormat=yyyy-MM-dd'T'HH:mm:ss.SSSZ" -DPRINT_WRAPPER=false -Dcom.ibm.ws390.smf.smf1209.useTime=RESPONDED -Dcom.ibm.ws390.smf.smf1209.breakdown=BY_SERVER -jar smftools.jar "INFILE(SF.T01850.MTFTP.F001)" "PLUGIN(com.ibm.smf.was.plugins.ResponseTimes,STDOUT)"
Time,Server,Requests,AvgResponse,MaxResponse,AvgQueue,AvgDisp,AvgCPU,AvgOffload,AvgOffload%,AvgBytesRcvd,AvgBytesSent,URI
"2025-02-13T20:54:00.000+0000",LPAR1,42,1,7,0,0,0,0,0.8333333,0,0,MBean
"2025-02-13T20:54:00.000+0000",LPAR1,85,40,1426,0,40,4,2,0.6537468,0,0,MDBA
"2025-02-13T20:54:00.000+0000",LPAR1,22094,1,5102,0,1,0,0,0.43708295,533,9843,IIOP
"2025-02-13T20:54:00.000+0000",LPAR1,12,2,5,0,1,0,0,1.0,0,0,Other
"2025-02-13T20:55:00.000+0000",LPAR1,1,3,3,0,3,0,0,0.0,397,329,/Servlet1
```