### PR TITLE
Upgrade requests package to fix vulnerabilities

### DIFF
--- a/zOS-Automation/OMEGAMON-Integration/tems-rest-py/README.md
+++ b/zOS-Automation/OMEGAMON-Integration/tems-rest-py/README.md
@@ -4,6 +4,8 @@ A Python command-line tool for calling Tivoli Enterprise Monitoring Server (TEMS
 
 ## Quick Start
 
+Before you begin, ensure that you have Python >= 3.10 installed on your machine, otherwise the necessary dependency cannot be installed.
+
 ```bash
 # 1. Create virtual environment
 python3 -m venv venv
@@ -51,7 +53,7 @@ Credentials are loaded in this order (highest to lowest precedence):
    echo "TEMS_USERID=admin" >> ~/.env
    echo "TEMS_PASSWORD=secret" >> ~/.env
    chmod 600 ~/.env
-   
+
    # Run without credentials
    python call_tems.py --hostname tems.example.com --path /api/v1/system/nodes
    ```

--- a/zOS-Automation/OMEGAMON-Integration/tems-rest-py/requirements.txt
+++ b/zOS-Automation/OMEGAMON-Integration/tems-rest-py/requirements.txt
@@ -1,1 +1,1 @@
-requests>=2.31.0
+requests>=2.34.2


### PR DESCRIPTION
Upgrade requests package to fix vuln CVE-2026-44431 and CVE-2026-44432 in dependency urllib3.

Add latest version of `requests` package in `requirements.txt`. The previous version of the requests package included the dependency urllib3 at version 2.6.3. With the latest version of requests, urllib3 version 2.7.0 will be installed which fixes the vulnerabilities listed above.

State in `README.md` that Python 3.10 or higher must be used as this is required to install the latest version of the requests package.